### PR TITLE
Clarify roles of ~pieces and ~setList

### DIFF
--- a/forChanna.scd
+++ b/forChanna.scd
@@ -3,7 +3,7 @@
         s.options.memSize = 128 * 1024;
         s.options.sampleRate = 48000;
 
-	// ~libPath = "~/Documents/SC/2019/channa/V3/lib/".asAbsolutePath; // change as needed
+	~libPath = "~/Documents/SC/2019/channa/forChannaHorwitz/lib/".asAbsolutePath; // change as needed
         ~piecePath = ~libPath ++ "pieces/";
         ~pieces = ();
 
@@ -14,6 +14,16 @@
             ~pieces.add(p.title -> p)
         });
 
+        ~setList = (~libPath ++ "setList.scd").load;
+        ~setList.create(~pieces, [
+            \channaJar,
+//            \channaMary,
+//            \channaMary,
+//            \channaGuit,
+//            \channaMaryTwo,
+//            \channaMaryTwo
+        ]);
+
         ~score = (~libPath ++ "score.scd").load;
         ~score.create;
 
@@ -21,19 +31,47 @@
         ~colorMaker.create;
 
         ~player = (~libPath ++ "player.scd").load;
-        ~player.create(~score, ~pieces, 0.1, ~colorMaker);
+        ~player.create(~score, ~setList, 0.1, ~colorMaker);
 
-        /*
-        ~player.changeSetList([
-            \channaMary,
-            \channaMary,
-            \channaGuit,
-            \channaMaryTwo,
-            \channaMaryTwo
+        "Config OK!".postln
+    }.fork(AppClock)
+)
+
+~player.task.play(SystemClock)
+~player.task.stop
+    {
+        s.options.memSize = 128 * 1024;
+        s.options.sampleRate = 48000;
+
+	~libPath = "~/Documents/SC/2019/channa/forChannaHorwitz/lib/".asAbsolutePath; // change as needed
+        ~piecePath = ~libPath ++ "pieces/";
+        ~pieces = ();
+
+        PathName.new(~piecePath).files.collect({|f|
+            f.fullPath.load
+        }).do({|p|
+            p.init;
+            ~pieces.add(p.title -> p)
+        });
+
+        ~setList = (~libPath ++ "setList.scd").load;
+        ~setList.create(~pieces, [
+            \channaJar,
+//            \channaMary,
+//            \channaMary,
+//            \channaGuit,
+//            \channaMaryTwo,
+//            \channaMaryTwo
         ]);
-        */
 
-        ~player.changeSetList([\channaJar]);
+        ~score = (~libPath ++ "score.scd").load;
+        ~score.create;
+
+        ~colorMaker = (~libPath ++ "colorMaker.scd").load;
+        ~colorMaker.create;
+
+        ~player = (~libPath ++ "player.scd").load;
+        ~player.create(~score, ~setList, 0.1, ~colorMaker);
 
         "Config OK!".postln
     }.fork(AppClock)

--- a/lib/player.scd
+++ b/lib/player.scd
@@ -1,17 +1,15 @@
 (
     (
-        create: {|self, score, pieces, waitTime=0.1, display|
+        create: {|self, score, setList, waitTime=0.1, display|
             self.score = score;
-            self.pieces = pieces;
+            self.setList = setList;
             self.waitTime = waitTime;
             self.display = display;
-
-            self.setList = self.setList.isNil.if { pieces.keys.asArray.scramble } { self.setList };
             
             self.task = Task.new({
-                self.setList.do({|title|
+                self.setList.pieces.do({|piece|
                     waitTime.yield;
-                    self.playPiece(score, pieces[title], display)
+                    self.playPiece(score, piece, display)
                 })
             })
         },
@@ -32,11 +30,6 @@
             });
 
             piece[\teardown].notNil.if { piece.teardown }
-        },
-
-        changeSetList: {|self, setList|
-            self.setList = setList;
-            self.create(self.score, self.pieces, self.waitTime, self.display)
         }
     )
 )

--- a/lib/setList.scd
+++ b/lib/setList.scd
@@ -1,0 +1,11 @@
+(
+    (
+        create: {|self, pieces, setList| 
+            self.pieces = setList.isNil.if {
+                pieces.values.scramble
+            } {
+                setList.collect({|title| pieces[title] }) 
+            }
+        }
+    )
+)


### PR DESCRIPTION
In response to:

> the whole pass pieces as dictionary then select by pieces title is a little verbose and circular. Couldn't we just use pieces  or setlist, rather than both, as an array that get iterated through or do like piece.keyvalues or whatever that method is. Just seems like pieces have titles so that you can use titles to access them. 
> 
> I also think it would maybe be better to have setList get created during the initialization of player rather than set after, just seems a little cleaner.

This PR adds "first class" pseudo-object `~setList`, which is passed to `~player.create` instead of `~pieces` and changes the implementation of `~player` accordingly.

I think this addresses the spirit of your concerns, however I do think we need both the full set of available pieces (the contents of the directory at `~piecePath`) and the subset of them to be played by a given `~player`, as auditioning different subsets of `~pieces` in different orders is likely to be a common activity.

I agree that it seems awkward to have pieces associated with titles in the `~pieces` dict while also containing the titles themselves, but I think that it's reasonable and useful for a piece's title to be a property of that piece AND it's reasonable and intuitive to refer to pieces by title when constructing `~setList`.