### PR TITLE
Pieces helper

### DIFF
--- a/forChanna.scd
+++ b/forChanna.scd
@@ -9,10 +9,10 @@
         ~pieces = ();
 
         PathName.new(~piecePath).files.collect({|f|
-            f.fullPath.load;
+            f.fullPath.load
         }).do({|p|
             p.init;
-            ~pieces.add(p.title -> p);
+            ~pieces.add(p.title -> p)
         });
 
         ~playlist = (~libPath ++ "/helpers/playlist.scd").load;
@@ -42,7 +42,7 @@
         // \channaMaryTwo
     ]);
 
-    ~player.create(~score, ~playlist, 0.1, ~colorMaker);
+    ~player.create(~score, ~playlist, 0.1, ~colorMaker)
 )
 
 ~player.task.play(SystemClock)

--- a/forChanna.scd
+++ b/forChanna.scd
@@ -16,6 +16,7 @@
         });
 
         ~playlist = (~libPath ++ "/helpers/playlist.scd").load;
+        ~playlist.create(~pieces);
 
         ~score = (~libPath ++ "/models/score.scd").load;
         ~score.create;

--- a/forChanna.scd
+++ b/forChanna.scd
@@ -1,3 +1,5 @@
+/* SETUP */
+
 (
     {
         s.options.memSize = 128 * 1024;
@@ -14,14 +16,6 @@
         });
 
         ~playlist = (~libPath ++ "/helpers/playlist.scd").load;
-	    ~playlist.create(~pieces, [
-            \channaJar,
-//            \channaMary,
-//            \channaMary,
-//            \channaGuit,
-//            \channaMaryTwo,
-//            \channaMaryTwo
-	   ]);
 
         ~score = (~libPath ++ "/models/score.scd").load;
         ~score.create;
@@ -36,23 +30,19 @@
     }.fork(AppClock)
 )
 
-~player.task.play(SystemClock)
-~player.task.stop
-
+/* USAGE */
 
 (
+    ~playlist.create(~pieces, [
+        // \channaJar,
+        // \channaMary,
+        // \channaMary,
+        \channaGuit,
+        \channaMaryTwo,
+        // \channaMaryTwo
+    ]);
 
-~playlist.create(~pieces, [
-	// \channaJar,
-	// \channaMary,
-	// \channaMary,
-    \channaGuit,
-    \channaMaryTwo,
-	// \channaMaryTwo
-]);
-
-~player.create(~score, ~playlist, 0.1, ~colorMaker);
-
+    ~player.create(~score, ~playlist, 0.1, ~colorMaker);
 )
 
 ~player.task.play(SystemClock)

--- a/forChanna.scd
+++ b/forChanna.scd
@@ -4,19 +4,15 @@
     {
         s.options.memSize = 128 * 1024;
         s.options.sampleRate = 48000;
-	~libPath = "/Users/bkudler/forChannaHorwitz/lib/".asAbsolutePath; // change as needed
+	/* ~libPath = "/Users/bkudler/forChannaHorwitz/lib/".asAbsolutePath; // change as needed */
+	~libPath = "~/Documents/SC/2019/channa/forChanna/lib/".asAbsolutePath; // change as needed
         ~piecePath = ~libPath ++ "views/players/";
-        ~pieces = ();
 
-        PathName.new(~piecePath).files.collect({|f|
-            f.fullPath.load
-        }).do({|p|
-            p.init;
-            ~pieces.add(p.title -> p)
-        });
+        ~pieces = (~libPath ++ "/helpers/pieces.scd").load;
+        ~pieces.create(~piecePath);
 
         ~playlist = (~libPath ++ "/helpers/playlist.scd").load;
-        ~playlist.create(~pieces);
+        ~playlist.create(~pieces.directory);
 
         ~score = (~libPath ++ "/models/score.scd").load;
         ~score.create;
@@ -33,8 +29,12 @@
 
 /* USAGE */
 
+// list available pieces
+~pieces.postNames;
+
+// create new playlist and player
 (
-    ~playlist.create(~pieces, [
+    ~playlist.create(~pieces.directory, [
         // \channaJar,
         // \channaMary,
         // \channaMary,
@@ -46,5 +46,6 @@
     ~player.create(~score, ~playlist, 0.1, ~colorMaker)
 )
 
+// play playlist on player
 ~player.task.play(SystemClock)
 ~player.task.stop

--- a/forChanna.scd
+++ b/forChanna.scd
@@ -4,9 +4,8 @@
     {
         s.options.memSize = 128 * 1024;
         s.options.sampleRate = 48000;
-	/* ~libPath = "/Users/bkudler/forChannaHorwitz/lib/".asAbsolutePath; // change as needed */
-	~libPath = "~/Documents/SC/2019/channa/forChanna/lib/".asAbsolutePath; // change as needed
-        ~piecePath = ~libPath ++ "views/players/";
+	~libPath = "/Users/bkudler/forChannaHorwitz/lib".asAbsolutePath; // change as needed
+        ~piecePath = ~libPath ++ "/views/players";
 
         ~pieces = (~libPath ++ "/helpers/pieces.scd").load;
         ~pieces.create(~piecePath);

--- a/lib/controllers/player.scd
+++ b/lib/controllers/player.scd
@@ -1,13 +1,13 @@
 (
     (
-        create: {|self, score, setList, waitTime=0.1, display|
+        create: {|self, score, playlist, waitTime=0.1, display|
             self.score = score;
-            self.setList = setList;
+            self.playlist = playlist;
             self.waitTime = waitTime;
             self.display = display;
             
             self.task = Task.new({
-                self.setList.pieces.do({|piece|
+                self.playlist.pieces.do({|piece|
                     waitTime.yield;
                     self.playPiece(score, piece, display)
                 })

--- a/lib/helpers/pieces.scd
+++ b/lib/helpers/pieces.scd
@@ -1,0 +1,18 @@
+(
+    (
+        create: {|self, path|
+            self.directory = ();
+
+            PathName.new(path).files.collect({|f|
+                f.fullPath.load
+            }).do({|p|
+                p.init;
+                self.directory.add(p.title -> p)
+            })
+        },
+
+        postNames: {|self|
+            self.directory.keys.postln
+        }
+    )
+)


### PR DESCRIPTION
This PR makes the function that builds the Dictionary of pieces to `helpers/pieces.scd`. I think this makes the code more consistent and readable overall, but the idea predates the MVC reorganization, so the classification of `pieces.scd` as a "helper" is not set in stone.

I've also reinforced the distinction between the setup function and the usage example in forChanna.scd somewhat and done some general tidying. All "style guide" stuff is very much up for discussion/revision.