### PR TITLE
Clarify handling of Server

### DIFF
--- a/forChanna.scd
+++ b/forChanna.scd
@@ -20,6 +20,7 @@
         ~player = (~libPath ++ "/controllers/player.scd").load;
         ~player.create(~score, ~playlist, 0.1, ~colorMaker);
 
+        s.bootSync;
         "Config OK!".postln
     }.fork(AppClock)
 )

--- a/forChanna.scd
+++ b/forChanna.scd
@@ -20,7 +20,14 @@
         ~player = (~libPath ++ "/controllers/player.scd").load;
         ~player.create(~score, ~playlist, 0.1, ~colorMaker);
 
-        s.bootSync;
+        ~serverRunning = Condition.new;
+        s.reboot;
+        s.doWhenBooted({
+            ~serverRunning.test_(true);
+            ~serverRunning.signal
+        });
+        ~serverRunning.wait;
+
         "Config OK!".postln
     }.fork(AppClock)
 )

--- a/forChanna.scd
+++ b/forChanna.scd
@@ -2,8 +2,6 @@
 
 (
     {
-        s.options.memSize = 128 * 1024;
-        s.options.sampleRate = 48000;
 	~libPath = "/Users/bkudler/forChannaHorwitz/lib".asAbsolutePath; // change as needed
         ~piecePath = ~libPath ++ "/views/players";
 

--- a/lib/views/players/guit.scd
+++ b/lib/views/players/guit.scd
@@ -75,14 +75,8 @@
         }),
 
         init: {|self, length=0.4|
-            {
-                s.bootSync;
-
-                self.def.add;
-                s.sync;
-
-                self.colors = self.makeColors(length)
-            }.forkIfNeeded
+            self.def.add;
+            self.colors = self.makeColors(length)
         },
 
         notes: [

--- a/lib/views/players/jar.scd
+++ b/lib/views/players/jar.scd
@@ -37,12 +37,7 @@
         }),
 
         init: {|self|
-            {
-                s.bootSync;
-
-                self.def.add;
-                s.sync
-            }.forkIfNeeded
+            self.def.add
         },
 
         setup: {|self|

--- a/lib/views/players/mary.scd
+++ b/lib/views/players/mary.scd
@@ -38,15 +38,9 @@
         }),
 
         init: {|self, length=0.1, base=88.3125|
-            {
-                s.bootSync;
-
-                self.def.add;
-                s.sync;
-
-                self.lengths = self.makeLengths(length);
-                self.colors = self.makeColors(base)
-            }.forkIfNeeded
+            self.def.add;
+            self.lengths = self.makeLengths(length);
+            self.colors = self.makeColors(base)
         },
 
         setup: {|self|

--- a/lib/views/players/maryTwo.scd
+++ b/lib/views/players/maryTwo.scd
@@ -30,15 +30,9 @@
         }),
 
         init: {|self, length=4, base=80.525|
-            {
-                s.bootSync;
-
-                self.def.add;
-                s.sync;
-
-                self.lengths = self.makeLengths(length);
-                self.colors = self.makeColors(base)
-            }.forkIfNeeded
+            self.def.add;
+            self.lengths = self.makeLengths(length);
+            self.colors = self.makeColors(base)
         },
 
         setup: {|self|


### PR DESCRIPTION
This PR:

Removes unnecessary serverOptions from setup Routine.
No longer forks or boots Server in piece init functions.
Explicitly boots Server and syncs at end of setup Routine.

These changes follow from my proposals in #7 and I think they can be a basis for cleaner abstraction of setup.